### PR TITLE
Add 'Sphinx' to setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ config = {
     ],
     'zip_safe': False,
     'install_requires': ['Sphinx'],
+    'setup_requires': ['Sphinx', 'setuptools>=40.0'],
 }
 
 setup(**config)


### PR DESCRIPTION
During installation, `sphinx_removed_in` is imported to obtain the version, which in turn ends up importing `Sphinx`:

```python
__version__ = __import__('sphinx_removed_in').__version__
```

For this reason `Sphinx` should also be listed in the `setup_requires` section so `pip` properly installs `Sphinx` in order to install `sphinx_removed_in`.

Tried to use this extension in pytest (https://github.com/pytest-dev/pytest/issues/4568), but we can't build the docs because of this problem:

```
Collecting pygments-pytest>=1.1.0 (from -r C:\Users\bruno\pytest/doc/en/requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/49/3e/fc3a0102c4ae97430d34303c0963cc779e8a1c74a73fe6a04539665fdbb0/pygments_pytest-1.1.0-py2.py3-none-any.whl
Collecting sphinx>=1.8.2 (from -r C:\Users\bruno\pytest/doc/en/requirements.txt (line 2))
  Using cached https://files.pythonhosted.org/packages/ff/d5/3a8727d6f890b1ae45da72a55bf8449e9f2c535a444923b338c3f509f203/Sphinx-1.8.2-py2.py3-none-any.whl
Collecting sphinxcontrib-trio (from -r C:\Users\bruno\pytest/doc/en/requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/09/28/70870892f814a46db677872ba8da59936601d00f1109dc9359b122d3a8fc/sphinxcontrib_trio-1.0.1-py3-none-any.whl
Collecting sphinx-removed-in (from -r C:\Users\bruno\pytest/doc/en/requirements.txt (line 4))
  Using cached https://files.pythonhosted.org/packages/74/04/b6bcf18ddf8ac127b9f0c5dffd20542fdcfbf3db6b689947217bd46f4980/sphinx-removed-in-0.1.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\bruno\AppData\Local\Temp\pip-install-sqas3ip2\sphinx-removed-in\setup.py", line 5, in <module>
        __version__ = __import__('sphinx_removed_in').__version__
      File "C:\Users\bruno\AppData\Local\Temp\pip-install-sqas3ip2\sphinx-removed-in\sphinx_removed_in\__init__.py", line 1, in <module>
        from sphinx.locale import versionlabels
    ModuleNotFoundError: No module named 'sphinx'
```