### PR TITLE
Do not import sphinx at top level of sphinx_removed_in

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ config = {
     ],
     'zip_safe': False,
     'install_requires': ['Sphinx'],
-    'setup_requires': ['Sphinx', 'setuptools>=40.0'],
 }
 
 setup(**config)

--- a/sphinx_removed_in/__init__.py
+++ b/sphinx_removed_in/__init__.py
@@ -4,7 +4,7 @@ __version__ = '0.1.1'
 def setup(app):
     from sphinx.locale import versionlabels
     from sphinx.directives.other import VersionChange
-    
+
     for _directive in ['versionremoved', 'removed-in']:
         if _directive not in versionlabels:
             versionlabels[_directive] = 'Removed in version %s'

--- a/sphinx_removed_in/__init__.py
+++ b/sphinx_removed_in/__init__.py
@@ -1,11 +1,10 @@
-from sphinx.locale import versionlabels
-from sphinx.directives.other import VersionChange
-
-
 __version__ = '0.1.1'
 
 
 def setup(app):
+    from sphinx.locale import versionlabels
+    from sphinx.directives.other import VersionChange
+    
     for _directive in ['versionremoved', 'removed-in']:
         if _directive not in versionlabels:
             versionlabels[_directive] = 'Removed in version %s'


### PR DESCRIPTION
Follow up to https://github.com/MrSenko/sphinx-removed-in/pull/1: unfortunately `setup_requires` is not enough to fix the original issue, as `setup_requires` can't be evaluated at that point yet (ref: https://github.com/pytest-dev/pytest/pull/4570#issuecomment-448993809).