### PR TITLE
Declare as Sphinx parallel safe

### DIFF
--- a/sphinx_removed_in/__init__.py
+++ b/sphinx_removed_in/__init__.py
@@ -19,4 +19,8 @@ def setup(app):
             versionlabel_classes[_directive] = 'removed'
             app.add_directive(_directive, VersionChange)
 
-    return {'version': __version__}
+    return {
+        'version': __version__,
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }


### PR DESCRIPTION
This should enable projects using this Sphinx extension to run in parallel mode (`sphinx-build -j N`). AFAICT this extension is parallel safe, see requirements here:
https://www.sphinx-doc.org/en/master/extdev/index.html#extension-metadata